### PR TITLE
Generalize root_key for AugmentedDataset

### DIFF
--- a/mlworkflow/datasets.py
+++ b/mlworkflow/datasets.py
@@ -315,8 +315,12 @@ class AugmentedDataset(Dataset, metaclass=ABCMeta):
         for root_key in self.dataset.list_keys():
             yield from self._augment(root_key).keys()
 
+    def root_key(self, key):
+        return key[0]
+
     def query_item(self, key):
-        return self._augment(key[0])[key]
+        root_key = self.root_key(key)
+        return self._augment(root_key)[key]
 
     @abstractmethod
     def augment(self, root_key, root_item):


### PR DESCRIPTION
Re-defining the function `root_key(self, key)` in an `AugmentedDataset` allows to define the root_key used for a given new_key. Default is `new_key[0]`.